### PR TITLE
mark all inputs of sweep transactions as owned

### DIFF
--- a/lnd/src/main/java/de/cotto/bitbook/lnd/features/SweepTransactionsService.java
+++ b/lnd/src/main/java/de/cotto/bitbook/lnd/features/SweepTransactionsService.java
@@ -3,6 +3,7 @@ package de.cotto.bitbook.lnd.features;
 import de.cotto.bitbook.backend.AddressDescriptionService;
 import de.cotto.bitbook.backend.TransactionDescriptionService;
 import de.cotto.bitbook.backend.transaction.TransactionService;
+import de.cotto.bitbook.backend.transaction.model.Input;
 import de.cotto.bitbook.backend.transaction.model.Transaction;
 import de.cotto.bitbook.ownership.AddressOwnershipService;
 import org.springframework.stereotype.Component;
@@ -50,12 +51,13 @@ public class SweepTransactionsService {
     }
 
     private void addAddressDescriptions(Transaction transaction) {
-        addressDescriptionService.set(getInputAddress(transaction), DEFAULT_ADDRESS_DESCRIPTION);
+        getInputAddresses(transaction)
+                .forEach(address -> addressDescriptionService.set(address, DEFAULT_ADDRESS_DESCRIPTION));
         addressDescriptionService.set(getOutputAddress(transaction), DEFAULT_ADDRESS_DESCRIPTION);
     }
 
     private void setAddressesAsOwned(Transaction transaction) {
-        addressOwnershipService.setAddressAsOwned(getInputAddress(transaction));
+        getInputAddresses(transaction).forEach(addressOwnershipService::setAddressAsOwned);
         addressOwnershipService.setAddressAsOwned(getOutputAddress(transaction));
     }
 
@@ -67,7 +69,7 @@ public class SweepTransactionsService {
         return transaction.getOutputs().get(0).getAddress();
     }
 
-    private String getInputAddress(Transaction transaction) {
-        return transaction.getInputs().get(0).getAddress();
+    private Set<String> getInputAddresses(Transaction transaction) {
+        return transaction.getInputs().stream().map(Input::getAddress).collect(toSet());
     }
 }

--- a/lnd/src/test/java/de/cotto/bitbook/lnd/features/SweepTransactionsServiceTest.java
+++ b/lnd/src/test/java/de/cotto/bitbook/lnd/features/SweepTransactionsServiceTest.java
@@ -102,7 +102,7 @@ class SweepTransactionsServiceTest {
 
         @Test
         void accepts_two_inputs() {
-            // this may happen for closed channels with unsettled HTLCs
+            // this may happen for closed channels with unsettled HTLCs or claimed anchors
             when(transactionService.getTransactionDetails(Set.of(TRANSACTION_HASH, TRANSACTION_HASH_2)))
                     .thenReturn(Set.of(TRANSACTION_4, SWEEP_TRANSACTION_2));
             assertThat(sweepTransactionsService.addFromSweeps(Set.of(TRANSACTION_HASH, TRANSACTION_HASH_2)))
@@ -130,6 +130,16 @@ class SweepTransactionsServiceTest {
         }
 
         @Test
+        void sets_address_descriptions_for_all_inputs() {
+            when(transactionService.getTransactionDetails(Set.of(TRANSACTION_HASH, TRANSACTION_HASH_2)))
+                    .thenReturn(Set.of(TRANSACTION_4));
+            sweepTransactionsService.addFromSweeps(hashes);
+
+            TRANSACTION_4.getInputs()
+                    .forEach(input -> verify(addressDescriptionService).set(input.getAddress(), DEFAULT_DESCRIPTION));
+        }
+
+        @Test
         void sets_address_ownership() {
             sweepTransactionsService.addFromSweeps(hashes);
 
@@ -137,6 +147,16 @@ class SweepTransactionsServiceTest {
             verify(addressOwnershipService).setAddressAsOwned(INPUT_SWEEP_2.getAddress());
             verify(addressOwnershipService).setAddressAsOwned(OUTPUT_SWEEP_1.getAddress());
             verify(addressOwnershipService).setAddressAsOwned(OUTPUT_SWEEP_2.getAddress());
+        }
+
+        @Test
+        void sets_address_ownership_for_all_inputs() {
+            when(transactionService.getTransactionDetails(Set.of(TRANSACTION_HASH, TRANSACTION_HASH_2)))
+                    .thenReturn(Set.of(TRANSACTION_4));
+            sweepTransactionsService.addFromSweeps(hashes);
+
+            TRANSACTION_4.getInputs()
+                    .forEach(input -> verify(addressOwnershipService).setAddressAsOwned(input.getAddress()));
         }
     }
 

--- a/lnd/src/test/java/de/cotto/bitbook/lnd/model/ResolutionTest.java
+++ b/lnd/src/test/java/de/cotto/bitbook/lnd/model/ResolutionTest.java
@@ -8,16 +8,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ResolutionTest {
 
     private static final String COMMIT = "COMMIT";
+    private static final String ANCHOR = "ANCHOR";
     private static final String CLAIMED = "CLAIMED";
+    private static final String FIRST_STAGE = "FIRST_STAGE";
     private static final String TIMEOUT = "TIMEOUT";
     private static final String INCOMING_HTLC = "INCOMING_HTLC";
     private static final String OUTGOING_HTLC = "OUTGOING_HTLC";
     private static final String SWEEP_TRANSACTION_HASH = "bar";
     private static final Resolution RESOLUTION_COMMIT_CLAIMED = new Resolution(SWEEP_TRANSACTION_HASH, COMMIT, CLAIMED);
+    private static final Resolution RESOLUTION_ANCHOR_CLAIMED = new Resolution(SWEEP_TRANSACTION_HASH, ANCHOR, CLAIMED);
 
     @Test
     void sweepTransactionClaimsFunds_commit_claimed() {
         assertThat(RESOLUTION_COMMIT_CLAIMED.sweepTransactionClaimsFunds()).isTrue();
+    }
+
+    @Test
+    void sweepTransactionClaimsFunds_anchor_claimed() {
+        assertThat(RESOLUTION_ANCHOR_CLAIMED.sweepTransactionClaimsFunds()).isTrue();
     }
 
     @Test
@@ -41,6 +49,12 @@ class ResolutionTest {
     @Test
     void sweepTransactionClaimsFunds_outgoing_htlc_timeout() {
         assertThat(new Resolution(SWEEP_TRANSACTION_HASH, OUTGOING_HTLC, TIMEOUT)
+                .sweepTransactionClaimsFunds()).isTrue();
+    }
+
+    @Test
+    void sweepTransactionClaimsFunds_outgoing_htlc_first_stage() {
+        assertThat(new Resolution(SWEEP_TRANSACTION_HASH, OUTGOING_HTLC, FIRST_STAGE)
                 .sweepTransactionClaimsFunds()).isTrue();
     }
 


### PR DESCRIPTION
when claiming an anchor, the sweep transaction may have several inputs (e.g. https://mempool.space/tx/2411b0ce4ef615f1db5463ab6fdb92557c402f0f3c7a97bcc45cc0c65f840759)